### PR TITLE
Add options to recover data from a broken RDB disk

### DIFF
--- a/amitools/fs/block/Block.py
+++ b/amitools/fs/block/Block.py
@@ -25,6 +25,8 @@ class Block:
     ST_USERDIR = 2
     ST_FILE = -3 & 0xFFFFFFFF
 
+    ignore_errors = False
+
     def __init__(self, blkdev, blk_num, is_type=0, is_sub_type=0, chk_loc=5):
         self.valid = False
         self.blkdev = blkdev
@@ -71,7 +73,7 @@ class Block:
             self._read_data()
         self._get_types()
         self._get_chksum()
-        self.valid = self.valid_types and self.valid_chksum
+        self.valid = (self.valid_types and self.valid_chksum) or Block.ignore_errors
 
     def write(self):
         if self.data == None:

--- a/amitools/fs/block/Block.py
+++ b/amitools/fs/block/Block.py
@@ -36,6 +36,7 @@ class Block:
         self.is_type = is_type
         self.is_sub_type = is_sub_type
         self.chk_loc = chk_loc
+        self.errors = []
 
     def __str__(self):
         return "%s:@%d" % (self.__class__.__name__, self.blk_num)
@@ -129,9 +130,11 @@ class Block:
         self.valid_types = True
         if self.is_type != 0:
             if self.type != self.is_type:
+                self.errors.append("Block #%d type mismatch (is %d but expected %d)" % (self.blk_num, self.type, self.is_type))
                 self.valid_types = False
         if self.is_sub_type != 0:
             if self.sub_type != self.is_sub_type:
+                self.errors.append("Block #%d subtype mismatch (is %d but expected %d)" % (self.blk_num, self.sub_type, self.is_sub_type))
                 self.valid_types = False
 
     def _put_types(self):
@@ -144,6 +147,8 @@ class Block:
         self.got_chksum = self._get_long(self.chk_loc)
         self.calc_chksum = self._calc_chksum()
         self.valid_chksum = self.got_chksum == self.calc_chksum
+        if not self.valid_chksum:
+            self.errors.append("Block #%d checksum is invalid" % (self.blk_num))
 
     def _put_chksum(self):
         self.calc_chksum = self._calc_chksum()

--- a/amitools/fs/block/Block.py
+++ b/amitools/fs/block/Block.py
@@ -73,7 +73,7 @@ class Block:
             self._read_data()
         self._get_types()
         self._get_chksum()
-        self.valid = (self.valid_types and self.valid_chksum) or Block.ignore_errors
+        self.valid = self.valid_types and (self.valid_chksum or Block.ignore_errors)
 
     def write(self):
         if self.data == None:

--- a/amitools/fs/rdb/FileSystem.py
+++ b/amitools/fs/rdb/FileSystem.py
@@ -155,10 +155,9 @@ class FileSystem:
         }
 
     def log_errors(self):
-        if not self.valid:
-            for i in self.lsegs:
-                for e in self.i.errors:
-                    logging.info(e)
+        for i in self.lsegs:
+            for e in i.errors:
+                logging.warning(e)
 
 
     # ----- edit -----

--- a/amitools/fs/rdb/FileSystem.py
+++ b/amitools/fs/rdb/FileSystem.py
@@ -2,6 +2,7 @@ from amitools.fs.block.rdb.FSHeaderBlock import *
 from amitools.fs.block.rdb.LoadSegBlock import *
 from amitools.util.HexDump import *
 import amitools.fs.DosType as DosType
+import logging
 
 
 class FileSystem:
@@ -152,6 +153,13 @@ class FileSystem:
             "size": len(self.data),
             "dev_node": dev_node,
         }
+
+    def log_errors(self):
+        if not self.valid:
+            for i in self.lsegs:
+                for e in self.i.errors:
+                    logging.info(e)
+
 
     # ----- edit -----
 

--- a/amitools/fs/rdb/Partition.py
+++ b/amitools/fs/rdb/Partition.py
@@ -3,6 +3,7 @@ from amitools.fs.block.rdb.PartitionBlock import *
 from amitools.fs.blkdev.PartBlockDevice import PartBlockDevice
 import amitools.util.ByteSize as ByteSize
 import amitools.fs.DosType as DosType
+import logging
 
 
 class Partition:
@@ -155,6 +156,12 @@ class Partition:
             "bootable": bootable,
             "automount": automount,
         }
+
+    def log_errors(self):
+        if not self.valid:
+            for e in self.part_blk.errors:
+                logging.info(e)
+
 
     # ----- Import/Export -----
 

--- a/amitools/fs/rdb/Partition.py
+++ b/amitools/fs/rdb/Partition.py
@@ -7,13 +7,13 @@ import logging
 
 
 class Partition:
-    def __init__(self, blkdev, blk_num, num, cyl_blks, rdisk):
+    def __init__(self, blkdev, blk_num, num, cyl_blks, block_bytes, rdisk=None):
         self.blkdev = blkdev
         self.blk_num = blk_num
         self.num = num
         self.cyl_blks = cyl_blks
+        self.block_bytes = block_bytes
         self.rdisk = rdisk
-        self.block_bytes = rdisk.block_bytes
         self.part_blk = None
 
     def get_next_partition_blk(self):

--- a/amitools/fs/rdb/Partition.py
+++ b/amitools/fs/rdb/Partition.py
@@ -158,9 +158,8 @@ class Partition:
         }
 
     def log_errors(self):
-        if not self.valid:
-            for e in self.part_blk.errors:
-                logging.info(e)
+        for e in self.part_blk.errors:
+            logging.warning(e)
 
 
     # ----- Import/Export -----

--- a/amitools/fs/rdb/RDisk.py
+++ b/amitools/fs/rdb/RDisk.py
@@ -49,8 +49,9 @@ class RDisk:
         num = 0
         while part_blk != Block.no_blk:
             p = Partition(self.rawblk, part_blk, num, self.rdb.log_drv.cyl_blks, self)
-            if not p.read():
-                p.log_errors()
+            ok = p.read()
+            p.log_errors()
+            if not ok:
                 self.valid = False
                 return False
             self.parts.append(p)
@@ -66,8 +67,9 @@ class RDisk:
         num = 0
         while fs_blk != PartitionBlock.no_blk:
             fs = FileSystem(self.rawblk, fs_blk, num)
-            if not fs.read():
-                fs.log_errors()
+            ok = fs.read()
+            fs.log_errors()
+            if not ok:
                 self.valid = False
                 return False
             self.fs.append(fs)

--- a/amitools/fs/rdb/RDisk.py
+++ b/amitools/fs/rdb/RDisk.py
@@ -48,7 +48,7 @@ class RDisk:
         self.parts = []
         num = 0
         while part_blk != Block.no_blk:
-            p = Partition(self.rawblk, part_blk, num, self.rdb.log_drv.cyl_blks, self)
+            p = Partition(self.rawblk, part_blk, num, self.rdb.log_drv.cyl_blks, self.block_bytes, self)
             ok = p.read()
             p.log_errors()
             if not ok:
@@ -634,7 +634,7 @@ class RDisk:
         self.rawblk.flush()
         # create partition object and add to partition list
         blk_per_cyl = blk_per_trk * heads
-        p = Partition(self.rawblk, blk_num, len(self.parts), blk_per_cyl, self)
+        p = Partition(self.rawblk, blk_num, len(self.parts), blk_per_cyl, self.block_bytes, self)
         p.read()
         self.parts.append(p)
         return p

--- a/amitools/fs/rdb/RDisk.py
+++ b/amitools/fs/rdb/RDisk.py
@@ -49,7 +49,6 @@ class RDisk:
         num = 0
         while part_blk != Block.no_blk:
             p = Partition(self.rawblk, part_blk, num, self.rdb.log_drv.cyl_blks, self)
-            num += 1
             if not p.read():
                 self.valid = False
                 return False
@@ -58,6 +57,7 @@ class RDisk:
             self.used_blks.append(p.get_blk_num())
             # next partition
             part_blk = p.get_next_partition_blk()
+            num += 1
 
         # read filesystems
         fs_blk = self.rdb.fs_list
@@ -65,7 +65,6 @@ class RDisk:
         num = 0
         while fs_blk != PartitionBlock.no_blk:
             fs = FileSystem(self.rawblk, fs_blk, num)
-            num += 1
             if not fs.read():
                 self.valid = False
                 return False
@@ -74,6 +73,7 @@ class RDisk:
             self.used_blks += fs.get_blk_nums()
             # next partition
             fs_blk = fs.get_next_fs_blk()
+            num += 1
 
         # TODO: add bad block blocks
 

--- a/amitools/fs/rdb/RDisk.py
+++ b/amitools/fs/rdb/RDisk.py
@@ -290,7 +290,7 @@ class RDisk:
     # ----- edit -----
 
     def create(
-        self, disk_geo, rdb_cyls=1, hi_rdb_blk=0, disk_names=None, ctrl_names=None
+        self, disk_geo, rdb_cyls=1, hi_rdb_blk=0, disk_names=None, ctrl_names=None, blk_num=0
     ):
         cyls = disk_geo.cyls
         heads = disk_geo.heads
@@ -340,15 +340,16 @@ class RDisk:
             ctrl_revision,
         )
         self.block_bytes = self.rawblk.block_bytes
-        self.rdb = RDBlock(self.rawblk)
+        self.rdb = RDBlock(self.rawblk, blk_num)
         self.rdb.create(
             phy_drv, log_drv, drv_id, block_size=self.block_bytes, flags=flags
         )
-        self.rdb.write()
-
         self.used_blks = [self.rdb.blk_num]
         self.max_blks = self.rdb.log_drv.rdb_blk_hi + 1
         self.valid = True
+
+    def write():
+        self.rdb.write()
 
     def resize(self, new_lo_cyl=None, new_hi_cyl=None, adjust_physical=False):
         # if the rdb region has to be minimized then check if no partition

--- a/amitools/fs/rdb/RDisk.py
+++ b/amitools/fs/rdb/RDisk.py
@@ -50,6 +50,7 @@ class RDisk:
         while part_blk != Block.no_blk:
             p = Partition(self.rawblk, part_blk, num, self.rdb.log_drv.cyl_blks, self)
             if not p.read():
+                p.log_errors()
                 self.valid = False
                 return False
             self.parts.append(p)
@@ -66,6 +67,7 @@ class RDisk:
         while fs_blk != PartitionBlock.no_blk:
             fs = FileSystem(self.rawblk, fs_blk, num)
             if not fs.read():
+                fs.log_errors()
                 self.valid = False
                 return False
             self.fs.append(fs)

--- a/amitools/fs/rdb/Recovery.py
+++ b/amitools/fs/rdb/Recovery.py
@@ -15,23 +15,20 @@ class Recovery:
         res = []
         for i in range(self.max_blks):
             blk = self.try_block_read(i)
-            res.append(blk)
+            if blk is not None:
+                res.append(blk)
         return res
 
     def try_block_read(self, i):
         p = Partition(self.rawblk, i, self.pnum, self.cyl_blks, self.block_bytes)
         if p.read():
-            return BlockRecord(p, [i], p.get_next_partition_blk())
+            self.pnum += 1
+            return p
         f = FileSystem(self.rawblk, i, self.fnum)
         if f.read():
-            return BlockRecord(f, f.get_blk_nums(), f.get_next_fs_blk())
+            self.fnum += 1
+            return f
         r = RDBlock(self.rawblk, i)
         if r.read():
-            return BlockRecord(r, [i], Block.no_blk)
-        return BlockRecord(None, [i], Block.no_blk)
-
-class BlockRecord:
-    def __init__(self, block, blocks, next):
-        self.block = block
-        self.blocks = blocks
-        self.next = next
+            return r
+        return None

--- a/amitools/fs/rdb/Recovery.py
+++ b/amitools/fs/rdb/Recovery.py
@@ -1,0 +1,37 @@
+from amitools.fs.block.rdb.RDBlock import *
+from .FileSystem import FileSystem
+from .Partition import Partition
+
+class Recovery:
+    def __init__(self, rawblk, block_bytes, cyl_blks, reserved_cyls):
+        self.rawblk = rawblk
+        self.max_blks = cyl_blks * reserved_cyls
+        self.block_bytes = block_bytes
+        self.cyl_blks = cyl_blks
+        self.pnum = 0
+        self.fnum = 0
+
+    def get_block_map(self):
+        res = []
+        for i in range(self.max_blks):
+            blk = self.try_block_read(i)
+            res.append(blk)
+        return res
+
+    def try_block_read(self, i):
+        p = Partition(self.rawblk, i, self.pnum, self.cyl_blks, self.block_bytes)
+        if p.read():
+            return BlockRecord(p, [i], p.get_next_partition_blk())
+        f = FileSystem(self.rawblk, i, self.fnum)
+        if f.read():
+            return BlockRecord(f, f.get_blk_nums(), f.get_next_fs_blk())
+        r = RDBlock(self.rawblk, i)
+        if r.read():
+            return BlockRecord(r, [i], Block.no_blk)
+        return BlockRecord(None, [i], Block.no_blk)
+
+class BlockRecord:
+    def __init__(self, block, blocks, next):
+        self.block = block
+        self.blocks = blocks
+        self.next = next

--- a/amitools/tools/rdbtool.py
+++ b/amitools/tools/rdbtool.py
@@ -312,6 +312,7 @@ class InitCommand(OpenCommand):
             rdb_cyls = 1
         rdisk = RDisk(blkdev)
         rdisk.create(blkdev.geo, rdb_cyls=rdb_cyls)
+        rdisk.write()
         return rdisk
 
 
@@ -512,9 +513,11 @@ class DiscoverCommand(Command):
             reserved_cyls = 2
 
         recovery = Recovery(blkdev, block_bytes, cyl_blks, reserved_cyls)
-        bm = recovery.get_block_map()
-        for i in bm:
-            print(i.dump())
+        recovery.read()
+        recovery.dump()
+
+        self.rdisk = recovery.build_rdisk()
+
         return 0
 
 

--- a/amitools/tools/rdbtool.py
+++ b/amitools/tools/rdbtool.py
@@ -513,15 +513,8 @@ class DiscoverCommand(Command):
 
         recovery = Recovery(blkdev, block_bytes, cyl_blks, reserved_cyls)
         bm = recovery.get_block_map()
-        off = 0
         for i in bm:
-            print("%06d: " % off, end="")
-            # print("%s, " % i.blocks, end="")
-            # print("next = %d" % (i.next if i.next != Block.no_blk else -1), end="")
-            print("")
-            if i.block != None:
-                print(i.block.dump())
-            off += 1
+            print(i.dump())
         return 0
 
 

--- a/amitools/tools/rdbtool.py
+++ b/amitools/tools/rdbtool.py
@@ -1082,11 +1082,21 @@ def main(args=None, defaults=None):
     parser.add_argument(
         "-t", "--dostype", default="ffs+intl", help="set default dos type"
     )
+    parser.add_argument(
+        "--ignore-block-errors",
+        action="store_true",
+        default=False,
+        help="ignore block errors",
+    )
+
     if defaults:
         parser.set_defaults(defaults)
     opts = parser.parse_args(args)
     opts.log_format = "%(message)s"
     setup_logging(opts)
+
+    if opts.ignore_block_errors:
+        Block.ignore_errors = True
 
     cmd_list = opts.command_list
     sep = opts.seperator

--- a/amitools/tools/rdbtool.py
+++ b/amitools/tools/rdbtool.py
@@ -1117,7 +1117,7 @@ def main(args=None, defaults=None):
         "--ignore-block-errors",
         action="store_true",
         default=False,
-        help="ignore block errors",
+        help="ignore block checksum errors",
     )
 
     if defaults:

--- a/amitools/util/Logging.py
+++ b/amitools/util/Logging.py
@@ -34,5 +34,8 @@ def setup_logging(opts):
             level = logging.INFO
         else:
             level = logging.DEBUG
+    format = FORMAT
+    if opts.log_format is not None:
+        format = opts.log_format
     # setup logging
-    logging.basicConfig(format=FORMAT, filename=opts.log_file, level=level)
+    logging.basicConfig(format=format, filename=opts.log_file, level=level)


### PR DESCRIPTION
rdbtool:
- Add the "ignore-block-errors" option to suppress checksum errors.
- Add the "discover" command to search for known blocks in the RDB area (with the possibility to export found partitions and file systems).
- Replace verbose prints with Logging.
